### PR TITLE
Allow transactionValue to be set to zero

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -656,7 +656,7 @@ function getEventMetadata(config) {
     eventMetadata.item_count = makeInteger(config.itemCount);
   }
 
-  if (config.transactionValue) {
+  if (typeof config.transactionValue !== 'undefined') {
     eventMetadata.value_decimal = makeNumber(config.transactionValue);
   }
 


### PR DESCRIPTION
An advertiser flagged that when they pass a value of 0 in `transactionValue`, the tag correctly picks up the zero value, but the CAPI request has the `value_decimal` set to null. 

This should be supported for events that normally have a value (e.g. sign ups) but sometimes don't (free trials).

Ana Gonzalez from SE was kind enough to find this fix for us and test it. She confirmed that it does allow a 0 value to be passed, and that it does not set the value to 0 if `transactionValue` isn't set.
