### PR TITLE
[ACS-3598] Add test_id support for Event Testing

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -847,7 +847,7 @@ function sendCAPIRequest(eventData) {
     events: [eventData],
     partner: CONSTANTS.CAPI_PARTNER,
   };
-  if (TEST_ID && TEST_ID != "") {
+  if (TEST_ID) {
     body.test_id = TEST_ID;
   } else {
     body.test_mode = TEST_MODE;


### PR DESCRIPTION
https://reddit.atlassian.net/browse/ACS-3598

* Add `test_id` to support CAPI Event Testing.
* Move `test_mode` along with `test_id` out of the "Authorization" params and into the root params.
* Skip sending `test_mode` if `test_id` is set as they are not compatible.
* Added rate limiting details to help text of both test_mode and test_id

Tested by copying the code into a custom template and verified that Event Testing is working

<img width="1200" height="352" alt="Screenshot 2025-08-06 at 12 44 42 PM" src="https://github.com/user-attachments/assets/b88a8e52-20c0-423e-ba0f-f0eb4639a5e7" />

