### PR TITLE
Fix testId helptext

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -232,7 +232,7 @@ ___TEMPLATE_PARAMETERS___
     "name": "test",
     "checkboxText": "Test Mode",
     "simpleValueType": true,
-    "help": "Enable this only while testing your tag configuration and setup. Disable in production! Events with this setting enabled are rate-limited to max 10 events per second.",
+    "help": "Enable this only while testing your tag configuration and setup. \u003cstrong\u003eDisable in production!\u003c/strong\u003e Events with this setting enabled are rate-limited to max 10 events per second.",
     "defaultValue": false
   },
   {
@@ -241,7 +241,7 @@ ___TEMPLATE_PARAMETERS___
     "displayName": "Test ID",
     "simpleValueType": true,
     "optional": true,
-    "help": "Enable this only for use with \u003ca href\u003d\"https://ads.reddit.com/events-manager/testing\"\u003eEvent Testing\u003c/a\u003e". Disable in production! Events with this setting enabled are rate-limited to max 10 events per second."
+    "help": "Enable this only for use with \u003ca href\u003d\"https://ads.reddit.com/events-manager/testing\"\u003eEvent Testing\u003c/a\u003e. \u003cstrong\u003eDisable in production!\u003c/strong\u003e Events with this setting enabled are rate-limited to max 10 events per second."
   },
   {
     "type": "CHECKBOX",


### PR DESCRIPTION
A stray doublequote ended up in the helptext for the new testId field added in #7, breaking the parsing of the template fields. This is likely the reason the latest version of the template wasn't picked up by GTM.

Removed the extra quote, and also added `<strong>` tags to the "Disable in production!" part of the helptext to make it stand out more.

Triple checked that it does parse correctly and displays as expected...

<img width="507" height="172" alt="Screenshot 2025-08-12 at 9 44 25 AM" src="https://github.com/user-attachments/assets/5f74868d-350f-4a26-9b53-50326a76bcec" />
<img width="563" height="139" alt="Screenshot 2025-08-12 at 9 44 32 AM" src="https://github.com/user-attachments/assets/1d6450a0-d7a1-4f0c-9295-3671a90f3ba7" />
