### PR TITLE
[ACS-3452] - Update template for 1-Click CAPI

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -908,7 +908,6 @@ function getUserData(eventData) {
         user.aaid = makeString(params.aaid);
       }
       if (params.email) {
-        // TODO: ask about getEmailFromCookie, this will never run if advancedMataching is not enabled
         user.email = makeString(params.email) || getEmailFromCookie();
       }
       if (params.externalId) {


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
## Closes [ACS-3452](https://reddit.atlassian.net/browse/ACS-3452)

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
This pr updates the template to support the upcoming automated Pixel + CAPI GTM flow. The primary changes here is to enable the server tag to process event data forwarded from the web container.

## 📜 Details
[Design Doc](https://docs.google.com/document/d/1Rb-ZII2cCTY2ZbmIA4dpvlJ_rFJLKIOudPQItYy8oO8/edit?tab=t.0#heading=h.atz7fiapoeu6) - [Relevant section](https://docs.google.com/document/d/1Rb-ZII2cCTY2ZbmIA4dpvlJ_rFJLKIOudPQItYy8oO8/edit?tab=t.0#heading=h.pr3j28i7ox42)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

### Key changes here:

- **enabled variable event types** - similar to the web template, the `eventType` parameter now supports GTM variables, allowing dynamic event names
- **passing integration_partner** - the template checks for a `integration_partner` key from the incoming `eventData` object, allowing us to distinguish between manual and automated setups
- **implemented eventData fallbacks** - metadata fields (`value`, `currency`, `products` & `itemCount`) and user data fields (`email` & `phone number`) are now collected if GTM UI configurations are not set from the `eventData` object being sent
- **adding template versioning** - we now have a `TEMPLATE_VERSION` constant which is sent in the CAPI payload

### More detail

#### Product Data Priority
before we only collected product data from manual UI configuration in the tag setting. after this pr the priority order is now:

1. **Manual UI Config** - data manually entered into the tag's settings (`Individual Entry` or `JSON Payload`) in **Product Information** dropdown is always the highest priority
2. **Google Analytics Ecommerce Items** - in the near future, the web container will have the ability to send ecommerce data directly to the event data object. This is the fallback priority. **NOTE** the logic to process the ecommerce items mirrors what we do in the web container. 
3. **Product Data Directly Pushed to DataLayer** - if no product data is collected from the above, we are also planning to collect product data from `productsRows` & `productsJSON` that gets pushed to the dataLayer to then be sent to the eventData object. 

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
