### PR TITLE
Fix the outdated documentation link

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.redditinc.com/advertising"
-documentation: "https://reddit.my.site.com/helpcenter/s/article/Install-the-Reddit-Pixel-on-your-website#GTM"
+documentation: "https://business.reddithelp.com/s/article/Set-Up-a-Server-Container"
 versions:
   # Latest Version
   - sha: b9eb9f63cb3e4eeac9b25a09e1edd23a0f9ad538


### PR DESCRIPTION
Simple fix for the updated documentation link. Credit to Ana for pointing this out.