### PR TITLE
Attempt to grab conversion_id from event data object

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -772,8 +772,9 @@ function processProductData(config, eventData) {
 function getEventMetadata(config, eventData) {
   let eventMetadata = {};
 
-  if (config.conversionId) {
-    eventMetadata.conversion_id = makeString(config.conversionId);
+  const conversionId = config.conversionId || eventData.conversion_id;
+  if (conversionId) {
+    eventMetadata.conversion_id = makeString(conversionId);
   }
 
   let transactionValue;


### PR DESCRIPTION
Follow up to #11, where we are grabbing event metadata from eventdata object. 