### PR TITLE
Fix sending undefined phone numbers in outbound request.

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -895,8 +895,8 @@ function getUserData(eventData) {
 
   user.phone_number =
     eventData.user_data &&
-    (makeString(eventData.user_data.phone_number) ||
-      makeString(eventData.user_data.sha256_phone_number));
+    ((eventData.user_data.phone_number && makeString(eventData.user_data.phone_number)) ||
+      (eventData.user_data.sha256_phone_number && makeString(eventData.user_data.sha256_phone_number)));
 
   if (
     data.advancedMatching &&


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->


## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
If phone number is not set, `"phone_number":"undefined"` is sent to the API endpoint. 

Seems to cause a suspiciously perfect event data presence rate?
<img width="631" height="130" alt="image" src="https://github.com/user-attachments/assets/b3beb22d-ee9b-4ec2-845a-41bf3e2d8cc4" />


## 📜 Details

Add check for variable presence prior to setting var.

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
Seems to work on my end. 
Needs official testing.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
