### PR TITLE
[ACS-4592] Add event source url support

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -592,6 +592,7 @@ function collectEventData() {
     const mappedEventData = {
       event_at: eventAtMs,
       action_source: data.actionSource || 'WEBSITE',
+      event_source_url: eventData.page_location,
       type: eventType,
       click_id: clickId,
       metadata: eventMetadata,
@@ -1370,6 +1371,22 @@ scenarios:
 
     verifyCAPI(function(requestUrl, requestOptions, requestBody) {
       assertThat(JSON.parse(requestBody).data.events[0].action_source).isEqualTo('OTHER');
+    });
+
+    runCode(testData);
+- name: Given page_location, verify event_source_url
+  code: |-
+    const testData = {
+    };
+
+    mock('getAllEventData', () => {
+      return {
+        page_location: "https://example.com"
+      };
+    });
+
+    verifyCAPI(function(requestUrl, requestOptions, requestBody) {
+      assertThat(JSON.parse(requestBody).data.events[0].event_source_url).isEqualTo('https://example.com');
     });
 
     runCode(testData);


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
We've already launched CAPI portion of event source URL, hence this new param is being ready for onboarding. Since SGTM template can automatically collect page URL, we actually don't need advertiser input but extract the field on their behalf and pass it to CAPI request. That way we can increase the domain coverage on CAPI events (which is currently at 0%).

Note that we don't need to truncate or sanitize the url in the template as we already handle it in PEP (see TDD for details).

## 📜 Details
[Design Doc](https://docs.google.com/document/d/1-oN_JPfj2z9M7kp4GhkqxpnwhA3zSVHGRnm066vBstI/edit?usp=sharing)

[Jira](https://reddit.atlassian.net/browse/ACS-4592)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
<img width="736" height="110" alt="Screenshot 2026-03-24 at 2 27 32 PM" src="https://github.com/user-attachments/assets/3338f611-65f8-4474-b64b-642d67562137" />
Added 2 test cases to verify that we will use `page_location` at best and if not then fallback to `page_referrer` as `event_source_url`

<img width="903" height="420" alt="Screenshot 2026-03-24 at 2 11 26 PM" src="https://github.com/user-attachments/assets/a29cee64-43e3-4245-b5a5-7ddda735b502" />
Also verified manually with the new template and confirm that `event_source_url` is correctly populated.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
