### PR TITLE
Add support for p2 pixel IDs

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -44,7 +44,7 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "args": [
-          "(t2_|a2_)[a-z0-9]+"
+          "(t2_|a2_|p2_)[a-z0-9]+"
         ],
         "type": "REGEX"
       }
@@ -53,7 +53,7 @@ ___TEMPLATE_PARAMETERS___
     "simpleValueType": true,
     "name": "id",
     "type": "TEXT",
-    "valueHint": "t2_***** or a2_*****",
+    "valueHint": "t2_*****, a2_*****, or p2_*****",
     "notSetText": "Please provide your Reddit Ads Pixel ID."
   },
   {


### PR DESCRIPTION
Adding support for the new pixel ID schema

Tested by copying the updated regex into the SS GTM template editor and verifying a p2_ prefixed pixel passes validation